### PR TITLE
Enhance documentation and add CLI install test for MCP server

### DIFF
--- a/.github/workflows/cli-install-test.yml
+++ b/.github/workflows/cli-install-test.yml
@@ -1,0 +1,52 @@
+name: CLI Install Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  npx-init-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build package artifact
+        id: package
+        shell: bash
+        run: echo "tarball=$(npm pack --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Run npx init in a clean project
+        shell: bash
+        run: |
+          project_dir="$(mktemp -d)"
+          cd "$project_dir"
+          npx --yes \
+            --package="$GITHUB_WORKSPACE/${{ steps.package.outputs.tarball }}" \
+            -- pudo-code-system init \
+            --yes \
+            --tools=cursor,claude,codex,copilot,gemini,opencode,kiro \
+            --project=nextjs \
+            --strictness=standard
+
+          test -f AGENTS.md
+          test -f CLAUDE.md
+          test -f GEMINI.md
+          test -f .cursor/rules/pudo-core.mdc
+          test -f .github/copilot-instructions.md
+          test -f .github/pull_request_template.md
+          test -f .pudo/config.json
+          test -f .pudo/session.md
+
+          npx --yes \
+            --package="$GITHUB_WORKSPACE/${{ steps.package.outputs.tarball }}" \
+            -- pudo-code-system check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is inspired by Keep a Changelog and organized for practical repositor
 
 ## [Unreleased]
 
+### Added
+
+- GitHub Actions CLI install smoke test that packs the npm artifact, runs `init` through `npx` in a clean project, verifies generated files, and runs `check`
+- README CI badge linking directly to the CLI install test
+
+### Changed
+
+- Promoted the MCP server to the primary agent-facing product surface in the README, with its callable tools and security boundaries shown before the CLI documentation
+- Updated the roadmap with packaged CLI verification and the path toward a publishable MCP server package
+
 ## [1.2.0] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 <h3 align="center">A portable operating layer for reliable AI-assisted development.</h3>
 
 <p align="center">
+  <a href="https://github.com/DongDuong2001/pudo-code-system/actions/workflows/cli-install-test.yml"><img src="https://github.com/DongDuong2001/pudo-code-system/actions/workflows/cli-install-test.yml/badge.svg" alt="CLI Install Test" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/version-1.2.0-brightgreen.svg" alt="Version 1.2.0" />
   <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-orange.svg" alt="PRs Welcome" /></a>
@@ -55,6 +56,30 @@ The issue isn't the AI — it's the **lack of structure**. Without a clear metho
 ## The Solution: PUDO
 
 **PUDO** is an AI Agent Operating Layer for configuring coding agents across Cursor, Claude, Codex, GitHub Copilot, and Gemini/Antigravity: installable rules, measurable quality gates, token-budgeted prompts, workflow templates, and benchmark evidence for real codebases.
+
+## The MCP Server Is The Product Surface
+
+The PUDO MCP server turns the operating layer into tools that compatible coding agents can call directly. Instead of relying on an agent to remember documentation, PUDO can generate and validate agent rules, create bounded context packs, run quality gates, score repository readiness, diagnose workflow gaps, initialize projects, and maintain session handoffs.
+
+| MCP Tool | What It Gives The Agent |
+|---|---|
+| `pudo.generateAgentRules` | Project-specific agent instructions |
+| `pudo.validateAgentRules` | Validation of installed workflow files |
+| `pudo.createContextPack` | Repository-bounded context without common sensitive or generated paths |
+| `pudo.runQualityGate` | Evidence checks before advancing or releasing |
+| `pudo.scoreRepoReadiness` | Machine-readable readiness scoring |
+| `pudo.doctor` | Workflow and policy gap diagnosis |
+| `pudo.initProject` | Approval-gated project initialization |
+| `pudo.updateSessionHandoff` | Approval-gated continuity between sessions |
+
+The alpha server uses local stdio, restricts reads to one configured repository root, requires explicit approval for writes, and exposes no shell or network execution.
+
+```bash
+npm install --prefix packages/pudo-mcp-server
+npm run mcp:test
+```
+
+See [PUDO MCP Server](docs/mcp.md), [Agent Tool Security](quality/agent-tool-security.md), and the [MCP Security Checklist](quality/mcp-security-checklist.md).
 
 Recent research on configuring agentic coding tools identifies repository-level context files as the dominant mechanism and notes `AGENTS.md` emerging as an interoperable standard across tools, while advanced mechanisms such as Skills and Subagents remain less adopted. PUDO starts from that repo-level layer and adds executable checks, quality gates, handoff, and measurement. ([arXiv:2602.14690](https://arxiv.org/abs/2602.14690))
 
@@ -98,17 +123,6 @@ npx pudo-code-system doctor
 ```
 
 `score` now evaluates instruction specificity, context quality, workflow evidence, AI/MCP safety, tests, CI, benchmarks, and release traceability. Its JSON output follows [schemas/pudo-score.schema.json](schemas/pudo-score.schema.json).
-
-## MCP Server Alpha
-
-PUDO `1.2.0` includes a local stdio MCP server alpha so compatible agents can call PUDO setup, validation, context-pack, quality-gate, readiness-score, and session-handoff tools.
-
-```bash
-npm install --prefix packages/pudo-mcp-server
-npm run mcp:test
-```
-
-Write tools require explicit approval, shell/network access is not exposed, and context reads are restricted to the configured repository root. See [PUDO MCP Server](docs/mcp.md), [Agent Tool Security](quality/agent-tool-security.md), and the [MCP Security Checklist](quality/mcp-security-checklist.md).
 
 ## Onboarding Paths
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,8 @@
 - Sample measured case studies
 - Context engineering guide
 - GitHub Action checker
+- Packaged CLI install smoke test covering `npx ... init` in a clean project
+- MCP server promoted as the primary agent-facing product surface
 
 ## v1.3
 
@@ -29,6 +31,7 @@
 - Run trace and metrics schemas
 - Team adoption guide
 - Case studies with measured outcomes
+- Publishable MCP server package and ready-to-use client configuration examples
 
 ## v1.4
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for CLI installation smoke testing, updates project documentation to highlight the MCP server as the primary product surface, and refines the roadmap to reflect these changes. The README now features a CI badge for the new install test and reorganizes content to emphasize the MCP server's agent-facing capabilities.

**CI/CD Improvements**
- Added a GitHub Actions workflow (`cli-install-test.yml`) that builds the npm package, runs `npx pudo-code-system init` in a clean environment, verifies generated files, and runs `check` to ensure CLI installability and integrity.

**Documentation Updates**
- Added a CI badge to the README linking directly to the new CLI install test for visibility.
- Promoted the MCP server as the primary agent-facing product surface in the README, including a detailed table of MCP tools and their functions for agents, and removed the separate "MCP Server Alpha" section in favor of this new organization. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60-R83) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-L112)
- Updated the changelog (`CHANGELOG.md`) to reflect the addition of the CLI install smoke test, the new CI badge, the README reorganization, and roadmap updates.

**Roadmap Refinement**
- Added entries to the roadmap for the packaged CLI install smoke test and for promoting the MCP server as the main product surface.
- Updated the roadmap to include plans for a publishable MCP server package and ready-to-use client configuration examples.