### PR TITLE
chore(mcp-server): bump version to 0.2.0-alpha.8

### DIFF
--- a/packages/pudo-mcp-server/README.md
+++ b/packages/pudo-mcp-server/README.md
@@ -4,7 +4,7 @@ Local stdio MCP server for PUDO project setup, quality gates, context packs, and
 
 ## Stability
 
-- Server version: `0.1.0-alpha.1`
+- Server version: `0.2.0-alpha.8` (from `package.json`)
 - MCP SDK: stable v1.x, pinned to `1.29.0`
 - Transport: local stdio
 - Repository boundary: one explicit project root

--- a/packages/pudo-mcp-server/package-lock.json
+++ b/packages/pudo-mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pudo-code-system/mcp-server",
-  "version": "0.2.0-alpha.7",
+  "version": "0.2.0-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pudo-code-system/mcp-server",
-      "version": "0.2.0-alpha.7",
+      "version": "0.2.0-alpha.8",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "^3.25.0"

--- a/packages/pudo-mcp-server/package.json
+++ b/packages/pudo-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dongduong2001/mcp-server",
-  "version": "0.2.0-alpha.7",
+  "version": "0.2.0-alpha.8",
   "description": "Local stdio MCP server for PUDO project setup, quality gates, context packs, and readiness scoring.",
   "type": "module",
   "bin": {

--- a/packages/pudo-mcp-server/src/server.ts
+++ b/packages/pudo-mcp-server/src/server.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerCheckTools } from "../tools/pudo_check.js";
@@ -11,12 +14,17 @@ import { registerScoreTools } from "../tools/pudo_score.js";
 import { registerSessionTools } from "../tools/pudo_session.js";
 import { resolveProjectRoot } from "../tools/core.js";
 
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const { version: serverVersion } = JSON.parse(
+  readFileSync(join(packageRoot, "package.json"), "utf8")
+) as { version: string };
+
 const projectRoot = resolveProjectRoot();
 process.chdir(projectRoot);
 
 const server = new McpServer({
   name: "pudo-mcp-server",
-  version: "0.1.0-alpha.1"
+  version: serverVersion
 });
 
 registerInitTools(server);


### PR DESCRIPTION
## Summary
- Bumps `@dongduong2001/mcp-server` to `0.2.0-alpha.8` for GitHub Packages and npm publish
- Reads server version from `package.json` at runtime to prevent version drift

## Test plan
- [x] `npm test` in `packages/pudo-mcp-server` (6/6 pass)
- [ ] Merge and push tag `v0.2.0-alpha.8` to trigger publish workflow


Made with [Cursor](https://cursor.com)